### PR TITLE
remove outdated comment about fork that has been merged upstream

### DIFF
--- a/axp209.py
+++ b/axp209.py
@@ -3,7 +3,6 @@
 from __future__ import print_function
 from ctypes import c_uint8, BigEndianStructure, Union
 
-# probably need to use my fork: pip install git+https://github.com/artizirk/smbus2
 from smbus2 import SMBus
 
 


### PR DESCRIPTION
The change was accepted upstream: https://github.com/kplindegaard/smbus2/pull/2 and released already

This is one reference missed in: e3b1355002ef667032d1fb7d7e1a6bc8c6147485