### PR TITLE
Add a way to set the bus number using and argument for the commandline utility, implement access to vbus current limit setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,14 @@ Installation
     pip install axp209
 
 
+SMBus bus number/object
+-----------------------
+
+The default SMBus object set in this library is an integer 0. You might need to 
+change to another integer[like 1] depending on your system, or pass an object.
+e.g. axp = AXP209(1) for the Olimex A20-SOM204.
+
+
 Examples
 --------
 

--- a/axp209.py
+++ b/axp209.py
@@ -111,7 +111,7 @@ class VBUS_CURRENT_LIMIT_CONTROL(Union):
         _fields_ = [
             ("vbus_available", c_uint8, 1),
             ("hold_pressure_limiting", c_uint8, 1),
-            ("hold_set_up", cuint8, 3),
+            ("hold_set_up", c_uint8, 3),
             ("_reserved_", c_uint8, 1),
             ("vbus_current_limit", c_uint8, 2),
         ]

--- a/axp209.py
+++ b/axp209.py
@@ -231,8 +231,8 @@ class AXP209(object):
             return -1
         return gauge
 
-def main():
-    axp = AXP209()
+def main(bus):
+    axp = AXP209(bus)
     print("internal_temperature: %.2fC" % axp.internal_temperature)
     print("battery_exists: %s" % axp.battery_exists)
     print("battery_charging: %s" % ("charging" if axp.battery_charging else "done"))
@@ -244,4 +244,23 @@ def main():
     axp.close()
 
 if __name__ == "__main__":
-    main()
+    import argparse
+    
+    parser = argparse.ArgumentParser(description='Create AXP209 PMS')
+    parser.add_argument('--busint', dest='busint', action='store_true', help='bus argument is interger')
+    parser.add_argument('--no-busint', dest='busint', action='store_false', help='bus argument is object')
+    parser.add_argument('--busnumber', metavar='Integer', dest='busnumber', type=int, required=False, help='the SMBus bus number [integer]')
+    parser.add_argument('--busobj', metavar='bus Object', dest='busobj', required=False, help='SMBus bus object')
+    parser.set_defaults(busint=True)
+    args = parser.parse_args()
+    					
+    if args.busint is True and args.busint is not None:
+        if args.busnumber is None:
+            main(bus=0)
+        else:
+            main(bus=int(args.busnumber))
+    else:
+        if args.busobj is None:
+            main()
+        else:
+            main(bus=args.busobj)

--- a/axp209.py
+++ b/axp209.py
@@ -193,7 +193,7 @@ class AXP209(object):
     @vbus_current_limit.setter    
     def vbus_current_limit(self, val):
         flags = VBUS_CURRENT_LIMIT_CONTROL()
-    	limits = { #00:900 mA; 01:500 mA; 10:100 mA; 11: not limit 
+        limits = { #00:900 mA; 01:500 mA; 10:100 mA; 11: not limit 
             0: "900 mA", 
             1: "500 mA", 
             2: "100 mA",


### PR DESCRIPTION
It is not obvious that the default set bus number is zero, so I added that in the README, also added some command line arguments.

Example:

    $python3.6 axp209.py --busint --busnumber 1
    internal_temperature: 34.60C
    battery_exists: True
    battery_charging: done
    battery_current_direction: discharging
    battery_voltage: 4162.4mV
    battery_discharge_current: 0.0mA
    battery_charge_current: 0.0mA
    battery_gauge: 99%

    $python3.6 axp209.py --no-busint --busobj busobject # I have no idea how this would be useful in terminal
